### PR TITLE
Add sphinx colour contrast extension

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -31,7 +31,7 @@ from os import environ
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ['sphinx_rtd_theme_ext_color_contrast']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 sphinx-rtd-theme
+sphinx-rtd-theme-ext-color-contrast


### PR DESCRIPTION
Applies the extension that's currently addressing the open WCAG issue against the Sphinx RTD theme https://github.com/readthedocs/sphinx_rtd_theme/issues/971

This _should_ cover the contrast issues noted in our audit.